### PR TITLE
Create log dir in correct place

### DIFF
--- a/recipes/_application.rb
+++ b/recipes/_application.rb
@@ -26,7 +26,7 @@ directory "#{node['fieri']['home']}/shared" do
   recursive true
 end
 
-directory "#{node['fieri']['home']}/log" do
+directory "#{node['fieri']['home']}/shared/log" do
   user 'fieri'
   group 'fieri'
   mode 0755

--- a/test/integration/default/serverspec/app_spec.rb
+++ b/test/integration/default/serverspec/app_spec.rb
@@ -12,4 +12,12 @@ describe 'fieri' do
   describe file('/srv/fieri/current/log') do
     it { should be_linked_to '/srv/fieri/shared/log' }
   end
+
+  describe file('/srv/fieri/shared') do
+    it { should be_directory }
+  end
+
+  describe file('/srv/fieri/shared/log') do
+    it { should be_directory }
+  end
 end


### PR DESCRIPTION
:fork_and_knife: Currently the log dir is being created in the cookbooks home directory, it should be created in the shared directory.
