### PR TITLE
pin redisio version

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,4 +3,4 @@ source 'https://api.berkshelf.com'
 metadata
 
 cookbook 'apt'
-cookbook 'redisio'
+cookbook 'redisio', '~> 1.7.1' # Versions > 1 use different recipes

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'supermarket@getchef.com'
 license          'Apache 2.0'
 description      'Installs/Configures fieri'
 long_description 'Installs/Configures fieri'
-version          '0.1.2'
+version          '0.1.3'
 
 depends          'apt'
 depends          'redisio'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,7 +6,6 @@
 #
 
 include_recipe 'redisio::install'
-include_recipe 'redisio::configure'
 include_recipe 'redisio::enable'
 
 include_recipe 'fieri::_apt'


### PR DESCRIPTION
When running the latest on prod, I got:

```
Chef::Exceptions::RecipeNotFound
--------------------------------
could not find recipe configure for cookbook redisio
```

This is because we were using 2.X of the redisio cookbook in test kitchen, but it's pinned to 1.7.1 in prod. This pins it to 1.7.1 in this cookbook's Berkshelf so Test Kitchen runs use the same version we use in prod.
